### PR TITLE
delimit entities consistently

### DIFF
--- a/ipNetVerify.php
+++ b/ipNetVerify.php
@@ -136,9 +136,9 @@ include 'include/header.php'
                 If you are currently attempting to use the UCSF VPN system and are having problems connecting to a site or network resource please contact your local CSC, computer administrator or the ITS Help Desk and provide them the information found in this box. 
             </div>
         <?php } ?>
-        <p>&nbsp</p>
-        <p>&nbsp</p>
-        <p>&nbsp</p>
+        <p>&nbsp;</p>
+        <p>&nbsp;</p>
+        <p>&nbsp;</p>
     </div>
     <?php
     include 'include/footer.php'


### PR DESCRIPTION
Delimit `&nbsp` entity with `;` consistently in the file. (It is sometimes and then isn't other times. This makes it that way all the time.)

Yeah, this is the tiniest of changes. Feel free to ignore. Or not. You know, like this text here. You don't need to read it. Unless you want to.